### PR TITLE
Add github workflows for BPI-R4 with BE14 and hostapd patch

### DIFF
--- a/.github/workflows/bpi-r4-BE14-hostapd-clean.yaml
+++ b/.github/workflows/bpi-r4-BE14-hostapd-clean.yaml
@@ -1,0 +1,117 @@
+---
+name: Build OpenWRT for Banana Pi R4 with BPI-R4-NIC-BE14 patch with Luci and hostpad patch
+
+on:
+  workflow_dispatch:
+
+env:
+  REMOTE_REPOSITORY: danpawlik/openwrt
+  REMOTE_BRANCH: be14-and-hostapd
+  RELEASE_PREFIX: Mediatek_mt7988a_bpi-r4_be14
+  DEVICE_CONFIG: configs/mediatek/mt7988a/bpi-r4
+  ROLE_CONFIG: configs/common/main-router
+
+jobs:
+  check_commits:
+    name: Check Commits
+    runs-on: ubuntu-24.04
+    outputs:
+      latest_commit_sha: ${{ steps.get_sha.outputs.latest_commit_sha }}
+    steps:
+      - name: Checkout remote repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.REMOTE_REPOSITORY }}
+          ref: ${{ env.REMOTE_BRANCH }}
+
+      - name: Get the latest commit SHA
+        id: get_sha
+        run: |
+          echo "latest_commit_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "latest_commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build BPI-R4 with BE14 + luci + hostapd patch
+    needs: [check_commits]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            build-essential clang flex bison g++ gawk \
+            gcc-multilib g++-multilib gettext git libncurses5-dev libssl-dev \
+            python3-setuptools rsync swig unzip zlib1g-dev file wget curl
+          sudo apt full-upgrade -y
+
+      - name: Checkout remote repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.REMOTE_REPOSITORY }}
+          ref: ${{ env.REMOTE_BRANCH }}
+
+      - name: Update and install feeds
+        run: |
+          ./scripts/feeds update -a
+          ./scripts/feeds install -a
+
+      - name: Configure firmware image
+        run: |
+          curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/mediatek/mt7988a/bpi-r4-simple > .config
+          curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/common/luci >> .config
+          curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/common/snapshot >> .config
+          make defconfig
+
+      - name: Remove packages that are marked as modules just to save time
+        run: |
+          grep "=m" .config | grep -v 'CONFIG_PACKAGE_libustream-mbedtls=m' | while read -r line; do module=$(echo "$line" | cut -f1 -d'='); sed -i "s/^$line$/# $module is not set/" .config; done
+
+      - name: Download dependencies
+        run: make -j $(nproc) download
+
+      - name: Build the firmware image
+        run: make -j $(nproc) world
+
+      - name: Package output
+        run: tar -cvf bpi_r4-images.tar bin/targets/mediatek/filogic
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bpi_r4-images
+          path: bpi_r4-images.tar
+
+  release:
+    name: Create release
+    needs: [build, check_commits]
+    if: needs.build.result == 'success'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: bpi_r4-images
+
+      - name: Extract artifacts
+        run: tar xf bpi_r4-images.tar
+
+      - name: Get current date
+        run: echo "RELEASE_DATE=$(date +%F)" >> $GITHUB_ENV
+
+      - name: Create release
+        uses: softprops/action-gh-release@master
+        with:
+          files: bin/targets/mediatek/filogic/*
+          tag_name: ${{ env.RELEASE_PREFIX }}-${{ env.REMOTE_BRANCH }}-${{ env.RELEASE_DATE }}
+          name: OpenWRT BPI-R4 with BE14 + luci + hostapd - ${{ env.REMOTE_BRANCH }} - ${{ env.RELEASE_DATE }}
+          body: |
+            Updated prebuilt images for ${{ env.RELEASE_DATE }}
+            Build Commit: ${{ needs.check_commits.outputs.latest_commit_sha }}
+
+      - name: Clean up old releases
+        uses: dev-drprasad/delete-older-releases@master
+        with:
+          keep_latest: 5
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Thanks to rmandrad [1][2], we can create an image with hostapd patch.

[1] https://forum.openwrt.org/t/banana-bpi-r4-wifi7-status/201051/89
[2] https://github.com/rmandrad/hostapd